### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Math::ThreeD",
+    "license" : "Artistic-2.0",
     "version" : "*",
     "description" : "A simple 3D library for Perl 6.",
     "author" : "raydiak",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license